### PR TITLE
changed slurm.saveResult to allow saving files bigger than 2gb

### DIFF
--- a/slurm.m
+++ b/slurm.m
@@ -745,7 +745,7 @@ classdef slurm < handle
                             result = o.command(['mkdir ' userFolderDir]); %#ok<NASGU>
                         end
                     %1.2 create the folder for the collated result within the user's sibdo folder    
-                        finalFolderDir = strrep(fullfile(o.headRootDir,finalFolderName, '/'),'\','/');
+                    	finalFolderDir = strrep(fullfile(o.headRootDir,finalFolderName, '/'),'\','/');
                         if ~o.exist(finalFolderDir,'dir')
                             result = o.command(['mkdir ' finalFolderDir]); %#ok<NASGU>
                         end
@@ -1690,7 +1690,11 @@ classdef slurm < handle
                 filename = [p f e];
             end
             fName =fullfile(tempDir,filename);
-            save(fName,'result');
+            try
+                save(fName,'result');
+            catch
+                save(fName,'result','-v7.3');
+            end
             % Copy to head
             scpCommand = ['scp ' fName ' ' jobDir];
             tic;


### PR DESCRIPTION
... but I added that option in a try-catch statement to allow slurm.saveResult to save file as '-v7.3' if file is too big but to not use that by default. I would just change it to that format in general but I am not sure if that format was avoided for a reason