### PR TITLE
slurm.saveResult now saves files as version 7.3

### DIFF
--- a/slurm.m
+++ b/slurm.m
@@ -1690,11 +1690,8 @@ classdef slurm < handle
                 filename = [p f e];
             end
             fName =fullfile(tempDir,filename);
-            try
-                save(fName,'result');
-            catch
-                save(fName,'result','-v7.3');
-            end
+            save(fName,'result','-v7.3');
+
             % Copy to head
             scpCommand = ['scp ' fName ' ' jobDir];
             tic;


### PR DESCRIPTION
doing it within a try-catch statement unfortunately doesn't work, so now the default format is '-v7.3